### PR TITLE
ci: add baseline script guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run repository validation
+        run: ./scripts/99-ci-validate.sh

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,24 @@
 # Progress Log
 
+## 2026-02-28 (23:34-23:40 UTC, CI guardrails bootstrap)
+
+Validation from this checkout:
+
+- Added first GitHub Actions workflow for repo integrity checks:
+  - `.github/workflows/ci.yml` runs on pull requests and pushes to `main`.
+  - workflow executes `./scripts/99-ci-validate.sh`.
+- Added deterministic CI validator script:
+  - bash syntax validation (`bash -n`) across all `scripts/*.sh`,
+  - executable-bit enforcement for operational scripts (`scripts/[0-9][0-9]-*.sh`).
+- Updated contributing guidance in `README.md` to run the same validator locally before opening PRs.
+- Local verification:
+  - `./scripts/99-ci-validate.sh` passes in this workspace.
+
+Assessment update:
+
+- Repo now has baseline automated regression detection for script-level breakage.
+- This closes a major process gap (no CI), reducing risk of syntax/executable regressions on future launch/auth/runtime fixes.
+
 ## 2026-02-28 (22:17-22:29 UTC, live post-restart DGX validation + retry auth-drift hardening)
 
 Validation from this checkout:

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+echo "==> Bash syntax checks"
+while IFS= read -r script_path; do
+  bash -n "${script_path}"
+done < <(find scripts -maxdepth 1 -type f -name '*.sh' | sort)
+
+echo "==> Executable bit checks"
+while IFS= read -r script_path; do
+  if [[ ! -x "${script_path}" ]]; then
+    echo "ERROR: expected executable script: ${script_path}" >&2
+    exit 1
+  fi
+done < <(find scripts -maxdepth 1 -type f -name '[0-9][0-9]-*.sh' | sort)
+
+echo "CI validation passed."


### PR DESCRIPTION
## Summary
- add first GitHub Actions workflow at `.github/workflows/ci.yml`
- add `scripts/99-ci-validate.sh` for deterministic repository checks
- document local pre-PR validation command in `README.md`
- log this CI bootstrap in `docs/progress.md`

## Validation
- `./scripts/99-ci-validate.sh`

Closes #1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds CI automation and a repo validation script that only checks shell syntax and executable bits, with no runtime behavior changes to product code.
> 
> **Overview**
> Adds a baseline GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs `./scripts/99-ci-validate.sh` on PRs and pushes to `main`.
> 
> Introduces `scripts/99-ci-validate.sh` to enforce `bash -n` syntax checks for all `scripts/*.sh` and verify executable permissions for operational `scripts/[0-9][0-9]-*.sh`, and updates docs (`README.md`, `docs/progress.md`) to reflect the new pre-PR/CI guardrails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 796f8b3510debd2d351c4f4901176359df6b7625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->