### PR TITLE
Add lock guardrails for concurrent orchestration runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ When `AUTO_REAUTH_ON_AUTH_FAILURE=1` is enabled and auth recovery fails, `90-rem
 `54-launch-and-capture-evidence.sh` now retries dispatch inside a single attempt (`DISPATCH_MAX_ATTEMPTS`, default `2`) and can auto-run `57-recover-steam-runtime.sh` between redispatches (`DISPATCH_RECOVER_ON_NO_ACCEPT=1`) before launch verification begins; these dispatch knobs are forwarded by `90-remote-dgx-stable-check.sh`.
 Pipe-write tuning is now also forwarded end-to-end by `90-remote-dgx-stable-check.sh`: `PIPE_WRITE_TIMEOUT_SECONDS` (default `6`), `PIPE_WRITE_RETRIES` (default `3`), `PIPE_WRITE_RETRY_DELAY_SECONDS`, `PIPE_WRITE_RECOVER_ON_TIMEOUT`, and URI fallback controls (`URI_FALLBACK_ON_PIPE_FAILURE`, `URI_FALLBACK_TIMEOUT_SECONDS`).
 When dispatch still fails, fallback now runs as an ordered chain (`DISPATCH_FALLBACK_CHAIN`, default `applaunch,steam_uri,snap_uri`) and can auto-normalize Steam windows first (`DISPATCH_FORCE_UI_ON_FAILURE=1`) to recover from hidden/off-screen UI states before retrying launch methods.
+Critical orchestrators now fail-fast on concurrent runs by default (`ENABLE_SCRIPT_LOCKS=1`): `54-launch-and-capture-evidence.sh`, `55-run-until-stable-runtime.sh`, and `90-remote-dgx-stable-check.sh`. Use `MSFS_LAUNCH_LOCK_WAIT_SECONDS`, `MSFS_STABLE_RUN_LOCK_WAIT_SECONDS`, and `MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS` to wait for active runs instead of exiting immediately.
 
 See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [docs/progress.md](docs/progress.md) for live validation notes.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,27 @@
 # Progress Log
 
+## 2026-03-01 (concurrency guardrails for critical orchestrators)
+
+Validation from this checkout:
+
+- Added shared lock helper: `scripts/lib-lock.sh`.
+- Added default lock guardrails (`ENABLE_SCRIPT_LOCKS=1`) to:
+  - `scripts/54-launch-and-capture-evidence.sh` (`launch-cycle-<appid>`, `MSFS_LAUNCH_LOCK_WAIT_SECONDS`)
+  - `scripts/55-run-until-stable-runtime.sh` (`stable-runner-<appid>`, `MSFS_STABLE_RUN_LOCK_WAIT_SECONDS`)
+  - `scripts/90-remote-dgx-stable-check.sh` (`remote-check-<appid>`, `MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS`)
+- Locking is fail-fast by default (`*_LOCK_WAIT_SECONDS=0`) and now returns deterministic `ERROR: lock busy` diagnostics instead of allowing overlapping runs that can race on Steam/MSFS state.
+- Updated docs:
+  - `README.md`
+  - `docs/setup-guide.md`
+  - `docs/troubleshooting.md`
+- Local verification:
+  - `bash -n scripts/lib-lock.sh scripts/54-launch-and-capture-evidence.sh scripts/55-run-until-stable-runtime.sh scripts/90-remote-dgx-stable-check.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This reduces a high-impact operational risk: concurrent launch orchestration collisions on DGX (which can destabilize Steam/MSFS and confound evidence/results).
+
 ## 2026-02-28 (23:45-23:50 UTC, secret removal + sudo guardrails)
 
 Validation from this checkout:

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -460,4 +460,10 @@ VKD3D_DEBUG=warn VKD3D_CONFIG=dxr %command% -FastLaunch
 
 # Disable DXVK HUD after initial testing
 # Just remove DXVK_HUD from launch options
+
+# Serialize launch/retry/remote orchestrators (enabled by default)
+ENABLE_SCRIPT_LOCKS=1
+MSFS_LAUNCH_LOCK_WAIT_SECONDS=0
+MSFS_STABLE_RUN_LOCK_WAIT_SECONDS=0
+MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS=0
 ```

--- a/scripts/54-launch-and-capture-evidence.sh
+++ b/scripts/54-launch-and-capture-evidence.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 MSFS_APPID="${MSFS_APPID:-2537590}"
 source "$SCRIPT_DIR/lib-display.sh"
+source "$SCRIPT_DIR/lib-lock.sh"
 source "$SCRIPT_DIR/lib-steam-auth.sh"
 DISPLAY_NUM="$(resolve_display_num "$SCRIPT_DIR")"
 WAIT_SECONDS="${WAIT_SECONDS:-240}"
@@ -32,9 +33,16 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 OUT_DIR="${OUT_DIR:-$REPO_ROOT/output}"
 STEAM_DIR="${STEAM_DIR:-$HOME/snap/steam/common/.local/share/Steam}"
 PFX="$STEAM_DIR/steamapps/compatdata/${MSFS_APPID}/pfx"
+ENABLE_SCRIPT_LOCKS="${ENABLE_SCRIPT_LOCKS:-1}"
+MSFS_LAUNCH_LOCK_WAIT_SECONDS="${MSFS_LAUNCH_LOCK_WAIT_SECONDS:-0}"
 
 mkdir -p "$OUT_DIR"
 RUN_START_EPOCH="$(date +%s)"
+
+if [ "$ENABLE_SCRIPT_LOCKS" = "1" ]; then
+  acquire_script_lock "launch-cycle-${MSFS_APPID}" "$MSFS_LAUNCH_LOCK_WAIT_SECONDS"
+  trap 'release_script_lock' EXIT
+fi
 
 if [ "$AUTH_BOOTSTRAP_STEAM_STACK" = "1" ]; then
   bootstrap_log="$OUT_DIR/auth-bootstrap-${MSFS_APPID}-${STAMP}.log"

--- a/scripts/55-run-until-stable-runtime.sh
+++ b/scripts/55-run-until-stable-runtime.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-lock.sh"
 MSFS_APPID="${MSFS_APPID:-2537590}"
 MIN_STABLE_SECONDS="${MIN_STABLE_SECONDS:-20}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
@@ -19,8 +20,15 @@ AUTH_USE_STEAM_LOGIN_CLI="${AUTH_USE_STEAM_LOGIN_CLI:-1}"
 ALLOW_UI_AUTH_FALLBACK="${ALLOW_UI_AUTH_FALLBACK:-0}"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 OUT_DIR="${OUT_DIR:-$REPO_ROOT/output}"
+ENABLE_SCRIPT_LOCKS="${ENABLE_SCRIPT_LOCKS:-1}"
+MSFS_STABLE_RUN_LOCK_WAIT_SECONDS="${MSFS_STABLE_RUN_LOCK_WAIT_SECONDS:-0}"
 
 mkdir -p "$OUT_DIR"
+
+if [ "$ENABLE_SCRIPT_LOCKS" = "1" ]; then
+  acquire_script_lock "stable-runner-${MSFS_APPID}" "$MSFS_STABLE_RUN_LOCK_WAIT_SECONDS"
+  trap 'release_script_lock' EXIT
+fi
 
 if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$MAX_ATTEMPTS" -lt 1 ]; then
   echo "ERROR: MAX_ATTEMPTS must be a positive integer (got: $MAX_ATTEMPTS)"

--- a/scripts/lib-lock.sh
+++ b/scripts/lib-lock.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Shared lock helpers for serializing critical MSFS orchestration scripts.
+set -euo pipefail
+
+acquire_script_lock() {
+  local lock_name="${1:?lock name required}"
+  local lock_wait_seconds="${2:-0}"
+  local locks_dir="${3:-${MSFS_LOCKS_DIR:-${XDG_RUNTIME_DIR:-/tmp}/msfs-on-dgx-spark-locks}}"
+  mkdir -p "$locks_dir"
+
+  if command -v flock >/dev/null 2>&1; then
+    MSFS_LOCK_FILE="$locks_dir/${lock_name}.lock"
+    exec {MSFS_LOCK_FD}> "$MSFS_LOCK_FILE"
+    if ! [[ "$lock_wait_seconds" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: lock wait must be a non-negative integer (got: $lock_wait_seconds)"
+      return 1
+    fi
+    if [ "$lock_wait_seconds" -gt 0 ]; then
+      flock -w "$lock_wait_seconds" "$MSFS_LOCK_FD" || {
+        echo "ERROR: lock busy: $lock_name (waited ${lock_wait_seconds}s)."
+        return 1
+      }
+    else
+      flock -n "$MSFS_LOCK_FD" || {
+        echo "ERROR: lock busy: $lock_name (set a *_LOCK_WAIT_SECONDS override to wait)."
+        return 1
+      }
+    fi
+    printf '%s\n' "$$" > "${MSFS_LOCK_FILE}.pid" || true
+    return 0
+  fi
+
+  if ! [[ "$lock_wait_seconds" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: lock wait must be a non-negative integer (got: $lock_wait_seconds)"
+    return 1
+  fi
+  MSFS_LOCK_DIR="$locks_dir/${lock_name}.lockdir"
+  local elapsed=0
+  while ! mkdir "$MSFS_LOCK_DIR" 2>/dev/null; do
+    if [ "$lock_wait_seconds" -eq 0 ] || [ "$elapsed" -ge "$lock_wait_seconds" ]; then
+      echo "ERROR: lock busy: $lock_name (mkdir fallback lock)."
+      return 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  printf '%s\n' "$$" > "${MSFS_LOCK_DIR}/pid" || true
+  return 0
+}
+
+release_script_lock() {
+  if [ -n "${MSFS_LOCK_FILE:-}" ]; then
+    rm -f "${MSFS_LOCK_FILE}.pid" 2>/dev/null || true
+  fi
+  if [ -n "${MSFS_LOCK_FD:-}" ]; then
+    flock -u "$MSFS_LOCK_FD" 2>/dev/null || true
+    eval "exec ${MSFS_LOCK_FD}>&-"
+  fi
+  if [ -n "${MSFS_LOCK_DIR:-}" ]; then
+    rm -f "${MSFS_LOCK_DIR}/pid" 2>/dev/null || true
+    rmdir "${MSFS_LOCK_DIR}" 2>/dev/null || true
+  fi
+}


### PR DESCRIPTION
## Summary
- add shared lock helper (`scripts/lib-lock.sh`) for cross-process orchestration locking
- serialize critical scripts by default:
  - `scripts/54-launch-and-capture-evidence.sh`
  - `scripts/55-run-until-stable-runtime.sh`
  - `scripts/90-remote-dgx-stable-check.sh`
- add fail-fast lock diagnostics with optional wait controls (`*_LOCK_WAIT_SECONDS`)
- document lock behavior and recovery/tuning in README + setup + troubleshooting
- log the change in `docs/progress.md`

## Why
Concurrent launch/retry/remote-check runs can race on shared Steam/MSFS state and produce unstable or misleading results. This change adds deterministic guardrails while preserving opt-in queued execution via wait overrides.

## Validation
- `bash -n scripts/lib-lock.sh scripts/54-launch-and-capture-evidence.sh scripts/55-run-until-stable-runtime.sh scripts/90-remote-dgx-stable-check.sh`
- `./scripts/99-ci-validate.sh`
- lock contention sanity check:
  - second concurrent lock acquisition exits with: `ERROR: lock busy: ...`

Closes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default behavior of core orchestration scripts to fail fast (or wait) under lock contention, which could break existing parallel workflows or leave stale locks if cleanup paths fail.
> 
> **Overview**
> Adds cross-process locking to **prevent concurrent MSFS orchestration runs**.
> 
> Introduces `scripts/lib-lock.sh` (uses `flock` with a mkdir fallback) and enables it by default (`ENABLE_SCRIPT_LOCKS=1`) in `54-launch-and-capture-evidence.sh`, `55-run-until-stable-runtime.sh`, and `90-remote-dgx-stable-check.sh`, with per-script wait controls (`MSFS_LAUNCH_LOCK_WAIT_SECONDS`, `MSFS_STABLE_RUN_LOCK_WAIT_SECONDS`, `MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS`) and deterministic `ERROR: lock busy` diagnostics.
> 
> Updates docs (`README.md`, `docs/setup-guide.md`, `docs/troubleshooting.md`, `docs/progress.md`) to describe the new serialization defaults, how to wait instead of failing, and how to disable locking as a last resort.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef73f0220cf62e7ef62952b7316eb015a78b6b8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->