### PR TITLE
CI: add shellcheck error-level guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
       - name: Run repository validation
         run: ./scripts/99-ci-validate.sh

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for core orchestrators, and hardcoded sudo-password pattern blocking).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for core orchestrators, hardcoded sudo-password pattern blocking, and `shellcheck -S error` across `scripts/*.sh`).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,24 @@
 # Progress Log
 
+## 2026-03-01 (ShellCheck error-level CI guardrails)
+
+Validation from this checkout:
+
+- Expanded `scripts/99-ci-validate.sh` with ShellCheck enforcement:
+  - requires `shellcheck` in `PATH`,
+  - runs `shellcheck -S error scripts/*.sh`,
+  - fails fast with actionable install guidance when missing.
+- Updated GitHub Actions workflow `.github/workflows/ci.yml`:
+  - installs `shellcheck` before running repository validation.
+- Updated `README.md` contributing guidance to include the new ShellCheck guardrail.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a key shell-quality gap by adding static error-level defect detection before merge, which is high leverage for a shell-orchestrated repository.
+
 ## 2026-03-01 (userspace tailscaled cleanup on remote-check exit)
 
 Validation from this checkout:

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -69,4 +69,12 @@ if grep -RInE "${hardcoded_sudo_pattern}" scripts/*.sh >/dev/null; then
   exit 1
 fi
 
+echo "==> ShellCheck error-level guardrails"
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "ERROR: shellcheck is required but was not found in PATH." >&2
+  echo "Install shellcheck locally or run in CI where it is provisioned." >&2
+  exit 1
+fi
+shellcheck -S error scripts/*.sh
+
 echo "CI validation passed."


### PR DESCRIPTION
## Summary
- install `shellcheck` in GitHub Actions CI
- enforce `shellcheck -S error scripts/*.sh` in `scripts/99-ci-validate.sh`
- update contributing guidance and progress log

## Why
The repo is primarily shell orchestration. Adding ShellCheck at error severity catches high-signal shell defects before merge and improves reliability with minimal noise.

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

Closes #11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/validation guardrails and documentation, but may cause new CI failures if any existing `scripts/*.sh` trigger ShellCheck errors or if contributors run validation without ShellCheck installed.
> 
> **Overview**
> Adds **ShellCheck error-level enforcement** to the repo’s validation pipeline by installing `shellcheck` in GitHub Actions and running `shellcheck -S error scripts/*.sh` from `scripts/99-ci-validate.sh` (failing fast with a clear message when missing).
> 
> Updates contributor docs (`README.md`, `docs/progress.md`) to reflect the new pre-PR requirement and the expanded CI guardrail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03ea213e1d2d9d8af53b1b01a8106dfb2e9ae713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->