### PR TITLE
Locking: reclaim stale fallback locks and improve busy diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ When `AUTO_REAUTH_ON_AUTH_FAILURE=1` is enabled and auth recovery fails, `90-rem
 Pipe-write tuning is now also forwarded end-to-end by `90-remote-dgx-stable-check.sh`: `PIPE_WRITE_TIMEOUT_SECONDS` (default `6`), `PIPE_WRITE_RETRIES` (default `3`), `PIPE_WRITE_RETRY_DELAY_SECONDS`, `PIPE_WRITE_RECOVER_ON_TIMEOUT`, and URI fallback controls (`URI_FALLBACK_ON_PIPE_FAILURE`, `URI_FALLBACK_TIMEOUT_SECONDS`).
 When dispatch still fails, fallback now runs as an ordered chain (`DISPATCH_FALLBACK_CHAIN`, default `applaunch,steam_uri,snap_uri`) and can auto-normalize Steam windows first (`DISPATCH_FORCE_UI_ON_FAILURE=1`) to recover from hidden/off-screen UI states before retrying launch methods.
 Critical orchestrators now fail-fast on concurrent runs by default (`ENABLE_SCRIPT_LOCKS=1`): `54-launch-and-capture-evidence.sh`, `55-run-until-stable-runtime.sh`, and `90-remote-dgx-stable-check.sh`. Use `MSFS_LAUNCH_LOCK_WAIT_SECONDS`, `MSFS_STABLE_RUN_LOCK_WAIT_SECONDS`, and `MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS` to wait for active runs instead of exiting immediately.
+Busy lock diagnostics now include lock-holder PID context when available (for example `holder pid: 12345`) and fallback lock mode can auto-reclaim stale lock directories by default (`MSFS_LOCK_RECLAIM_STALE=1`).
 
 See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [docs/progress.md](docs/progress.md) for live validation notes.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,24 @@
 # Progress Log
 
+## 2026-03-01 (lock diagnostics + stale-lock reclaim hardening)
+
+Validation from this checkout:
+
+- Improved shared lock behavior in `scripts/lib-lock.sh`:
+  - lock-busy diagnostics now include holder PID context when available,
+  - mkdir-fallback lock mode now auto-reclaims stale lock directories by default when recorded holder PID is no longer running.
+- Added `MSFS_LOCK_RECLAIM_STALE` (default `1`) to control stale-lock reclamation in fallback mode.
+- Updated docs:
+  - `README.md`
+  - `docs/troubleshooting.md`
+- Local verification:
+  - `bash -n scripts/lib-lock.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This reduces operational friction and false blocking in long-running headless orchestration by improving lock-owner observability and automatic cleanup of stale fallback locks.
+
 ## 2026-03-01 (ShellCheck error-level CI guardrails)
 
 Validation from this checkout:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,6 +132,7 @@ If unauthenticated failures occur with no active `steamwebhelper`, keep `AUTH_BO
 - `scripts/90-remote-dgx-stable-check.sh`
 
 **Cause**: another launch/retry/remote-check orchestration is already running; lock guardrails prevent overlapping runs from racing on Steam/MSFS state.
+Recent lock errors include holder PID context when discoverable (for example `holder pid: 12345`), which helps identify the active owner process.
 
 **Fix**:
 ```bash
@@ -142,6 +143,9 @@ MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS=600 ./scripts/90-remote-dgx-stable-check.sh
 
 # Last resort (not recommended): disable lock guardrails
 ENABLE_SCRIPT_LOCKS=0 ./scripts/90-remote-dgx-stable-check.sh
+
+# Optional: disable stale lockdir reclamation in mkdir-fallback mode
+MSFS_LOCK_RECLAIM_STALE=0 ./scripts/90-remote-dgx-stable-check.sh
 ```
 
 ### Dispatch not accepted (`exit 4`) after auth succeeds

--- a/scripts/lib-lock.sh
+++ b/scripts/lib-lock.sh
@@ -2,10 +2,64 @@
 # Shared lock helpers for serializing critical MSFS orchestration scripts.
 set -euo pipefail
 
+lock_holder_pid_from_file() {
+  local pid_file="${1:?pid file required}"
+  local holder_pid=""
+  if [ -f "$pid_file" ]; then
+    holder_pid="$(head -n 1 "$pid_file" 2>/dev/null | tr -d '[:space:]')"
+  fi
+  if [[ "$holder_pid" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$holder_pid"
+    return 0
+  fi
+  return 1
+}
+
+lock_pid_is_running() {
+  local holder_pid="${1:?pid required}"
+  ps -p "$holder_pid" >/dev/null 2>&1
+}
+
+lock_busy_holder_note() {
+  local pid_file="${1:?pid file required}"
+  local holder_pid=""
+  holder_pid="$(lock_holder_pid_from_file "$pid_file" 2>/dev/null || true)"
+  if [ -z "$holder_pid" ]; then
+    return 0
+  fi
+  if lock_pid_is_running "$holder_pid"; then
+    printf '(holder pid: %s)' "$holder_pid"
+  else
+    printf '(stale pid file: %s not running)' "$holder_pid"
+  fi
+}
+
+try_reclaim_stale_lockdir() {
+  local lock_dir="${1:?lock dir required}"
+  local pid_file="$lock_dir/pid"
+  local holder_pid=""
+
+  [ -d "$lock_dir" ] || return 1
+  holder_pid="$(lock_holder_pid_from_file "$pid_file" 2>/dev/null || true)"
+  [ -n "$holder_pid" ] || return 1
+
+  if lock_pid_is_running "$holder_pid"; then
+    return 1
+  fi
+
+  if rm -rf "$lock_dir" 2>/dev/null; then
+    echo "INFO: reclaimed stale lock: $lock_dir (pid $holder_pid not running)." >&2
+    return 0
+  fi
+  return 1
+}
+
 acquire_script_lock() {
   local lock_name="${1:?lock name required}"
   local lock_wait_seconds="${2:-0}"
   local locks_dir="${3:-${MSFS_LOCKS_DIR:-${XDG_RUNTIME_DIR:-/tmp}/msfs-on-dgx-spark-locks}}"
+  local lock_reclaim_stale="${MSFS_LOCK_RECLAIM_STALE:-1}"
+  local holder_note=""
   mkdir -p "$locks_dir"
 
   if command -v flock >/dev/null 2>&1; then
@@ -17,12 +71,14 @@ acquire_script_lock() {
     fi
     if [ "$lock_wait_seconds" -gt 0 ]; then
       flock -w "$lock_wait_seconds" "$MSFS_LOCK_FD" || {
-        echo "ERROR: lock busy: $lock_name (waited ${lock_wait_seconds}s)."
+        holder_note="$(lock_busy_holder_note "${MSFS_LOCK_FILE}.pid" || true)"
+        echo "ERROR: lock busy: $lock_name (waited ${lock_wait_seconds}s). ${holder_note}"
         return 1
       }
     else
       flock -n "$MSFS_LOCK_FD" || {
-        echo "ERROR: lock busy: $lock_name (set a *_LOCK_WAIT_SECONDS override to wait)."
+        holder_note="$(lock_busy_holder_note "${MSFS_LOCK_FILE}.pid" || true)"
+        echo "ERROR: lock busy: $lock_name (set a *_LOCK_WAIT_SECONDS override to wait). ${holder_note}"
         return 1
       }
     fi
@@ -37,8 +93,12 @@ acquire_script_lock() {
   MSFS_LOCK_DIR="$locks_dir/${lock_name}.lockdir"
   local elapsed=0
   while ! mkdir "$MSFS_LOCK_DIR" 2>/dev/null; do
+    if [ "$lock_reclaim_stale" = "1" ] && try_reclaim_stale_lockdir "$MSFS_LOCK_DIR"; then
+      continue
+    fi
     if [ "$lock_wait_seconds" -eq 0 ] || [ "$elapsed" -ge "$lock_wait_seconds" ]; then
-      echo "ERROR: lock busy: $lock_name (mkdir fallback lock)."
+      holder_note="$(lock_busy_holder_note "${MSFS_LOCK_DIR}/pid" || true)"
+      echo "ERROR: lock busy: $lock_name (mkdir fallback lock). ${holder_note}"
       return 1
     fi
     sleep 1


### PR DESCRIPTION
Closes #13

## What changed
- add lock-holder PID context to lock busy errors when available
- add stale lockdir reclamation in mkdir fallback mode when recorded holder PID is no longer running
- add `MSFS_LOCK_RECLAIM_STALE` env toggle (default `1`)
- document behavior in README and troubleshooting
- record validation in progress log

## Validation
- `bash -n scripts/lib-lock.sh`
- `./scripts/99-ci-validate.sh`
- stale lock reclaim helper smoke test via `try_reclaim_stale_lockdir`
