### PR TITLE
CI: add behavioral lock helper regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for core orchestrators, hardcoded sudo-password pattern blocking, and `shellcheck -S error` across `scripts/*.sh`).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for core orchestrators, hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,24 @@
 # Progress Log
 
+## 2026-03-01 (lock behavior regression tests in CI)
+
+Validation from this checkout:
+
+- Added deterministic lock behavior self-tests in `scripts/98-test-lock-lib.sh`:
+  - verifies contention fails fast with `ERROR: lock busy` diagnostics and holder PID context,
+  - verifies stale fallback lockdirs are reclaimed when holder PID is not running,
+  - verifies active lockdirs are preserved when holder PID is running.
+- Updated `scripts/99-ci-validate.sh` to execute `./scripts/98-test-lock-lib.sh` as part of local/CI validation.
+- Updated contributor guidance in `README.md` to document the new lock behavior test coverage.
+- Local verification:
+  - `bash -n scripts/98-test-lock-lib.sh scripts/99-ci-validate.sh` (pass)
+  - `./scripts/98-test-lock-lib.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a meaningful reliability gap by adding behavioral regression detection for locking semantics, not just syntax/lint checks.
+
 ## 2026-03-01 (lock diagnostics + stale-lock reclaim hardening)
 
 Validation from this checkout:

--- a/scripts/98-test-lock-lib.sh
+++ b/scripts/98-test-lock-lib.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-lock.sh
+source "$SCRIPT_DIR/lib-lock.sh"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+echo "[lock-test] contention emits busy diagnostics"
+(
+  MSFS_LOCKS_DIR="$tmp_dir" acquire_script_lock "ci-lock-contention" 0
+  sleep 3
+  release_script_lock
+) &
+holder_job_pid=$!
+
+lock_pid_file="$tmp_dir/ci-lock-contention.lock.pid"
+for _ in $(seq 1 40); do
+  [ -f "$lock_pid_file" ] && break
+  sleep 0.1
+done
+if [ ! -f "$lock_pid_file" ]; then
+  echo "ERROR: lock holder pid file was not created in time." >&2
+  wait "$holder_job_pid" || true
+  exit 1
+fi
+
+set +e
+contention_output="$(
+  MSFS_LOCKS_DIR="$tmp_dir" bash -c "source \"$SCRIPT_DIR/lib-lock.sh\"; acquire_script_lock 'ci-lock-contention' 0" 2>&1
+)"
+contention_rc=$?
+set -e
+
+wait "$holder_job_pid"
+
+if [ "$contention_rc" -eq 0 ]; then
+  echo "ERROR: contention test unexpectedly acquired lock." >&2
+  exit 1
+fi
+if ! grep -q "ERROR: lock busy: ci-lock-contention" <<<"$contention_output"; then
+  echo "ERROR: contention output missing lock-busy diagnostic." >&2
+  echo "$contention_output" >&2
+  exit 1
+fi
+if ! grep -q "holder pid:" <<<"$contention_output"; then
+  echo "ERROR: contention output missing holder pid context." >&2
+  echo "$contention_output" >&2
+  exit 1
+fi
+
+echo "[lock-test] stale lockdir reclaim removes non-running holder lock"
+stale_lock_dir="$tmp_dir/stale.lockdir"
+mkdir -p "$stale_lock_dir"
+printf '%s\n' 999999 > "$stale_lock_dir/pid"
+if ! try_reclaim_stale_lockdir "$stale_lock_dir" >/dev/null; then
+  echo "ERROR: stale lockdir reclaim should have succeeded." >&2
+  exit 1
+fi
+if [ -d "$stale_lock_dir" ]; then
+  echo "ERROR: stale lockdir still exists after reclaim." >&2
+  exit 1
+fi
+
+echo "[lock-test] stale reclaim preserves lockdir for running holder pid"
+active_lock_dir="$tmp_dir/active.lockdir"
+mkdir -p "$active_lock_dir"
+printf '%s\n' "$$" > "$active_lock_dir/pid"
+if try_reclaim_stale_lockdir "$active_lock_dir" >/dev/null; then
+  echo "ERROR: lockdir with running holder pid must not be reclaimed." >&2
+  exit 1
+fi
+if [ ! -d "$active_lock_dir" ]; then
+  echo "ERROR: active lockdir was unexpectedly removed." >&2
+  exit 1
+fi
+
+echo "Lock helper self-test passed."

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -77,4 +77,7 @@ if ! command -v shellcheck >/dev/null 2>&1; then
 fi
 shellcheck -S error scripts/*.sh
 
+echo "==> Lock helper behavioral self-test"
+./scripts/98-test-lock-lib.sh
+
 echo "CI validation passed."


### PR DESCRIPTION
## Summary
Add deterministic behavior tests for `scripts/lib-lock.sh` and run them in the existing CI validator.

## Changes
- add `scripts/98-test-lock-lib.sh` self-test covering:
  - contention path (`ERROR: lock busy` + holder pid context)
  - stale fallback lock reclaim for non-running PID
  - no reclaim when holder PID is running
- run the self-test from `scripts/99-ci-validate.sh`
- update contributor guidance in `README.md`
- log validation in `docs/progress.md`

## Validation
- `bash -n scripts/98-test-lock-lib.sh scripts/99-ci-validate.sh`
- `./scripts/98-test-lock-lib.sh`
- `./scripts/99-ci-validate.sh`

Closes #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/validation scripts and documentation, with no impact on runtime orchestration logic except additional test execution time and potential for CI failures if lock semantics regress.
> 
> **Overview**
> Adds a deterministic self-test script (`scripts/98-test-lock-lib.sh`) that regression-tests `scripts/lib-lock.sh` locking behavior (contention emits `ERROR: lock busy` with holder PID context, stale lockdir reclamation, and preservation of active lockdirs).
> 
> Updates `scripts/99-ci-validate.sh` to run the lock self-tests as part of local/CI validation, and refreshes `README.md` contributor guidance plus `docs/progress.md` to document the new behavioral coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7e2613297692e03ffe7c551c4123967ef47f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->