### PR TITLE
Expand strict-mode CI guardrails for full critical orchestration chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for core orchestrators, hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,26 @@
 # Progress Log
 
+## 2026-03-01 (expanded strict-mode CI guardrails across critical orchestration chain)
+
+Validation from this checkout:
+
+- Expanded strict-mode guardrails in `scripts/99-ci-validate.sh` to require `set -euo pipefail` in:
+  - `scripts/53-preflight-runtime-repair.sh`
+  - `scripts/54-launch-and-capture-evidence.sh`
+  - `scripts/55-run-until-stable-runtime.sh`
+  - `scripts/56-run-staged-stability-check.sh`
+  - `scripts/57-recover-steam-runtime.sh`
+  - `scripts/58-ensure-steam-auth.sh`
+  - `scripts/90-remote-dgx-stable-check.sh`
+- Updated `README.md` contributor guidance to reflect the expanded strict-mode coverage list.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a CI regression gap where strict-mode loss in preflight/staged/auth/recovery scripts could previously slip through despite those scripts being in the critical DGX launch reliability path.
+
 ## 2026-03-01 (lock behavior regression tests in CI)
 
 Validation from this checkout:

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -49,8 +49,12 @@ done < <(
 
 echo "==> Strict-mode guardrails (critical orchestrators)"
 critical_strict_scripts=(
+  "scripts/53-preflight-runtime-repair.sh"
   "scripts/54-launch-and-capture-evidence.sh"
   "scripts/55-run-until-stable-runtime.sh"
+  "scripts/56-run-staged-stability-check.sh"
+  "scripts/57-recover-steam-runtime.sh"
+  "scripts/58-ensure-steam-auth.sh"
   "scripts/90-remote-dgx-stable-check.sh"
 )
 for script_path in "${critical_strict_scripts[@]}"; do


### PR DESCRIPTION
## Summary
- expand CI strict-mode guardrails from `54/55/90` to the full critical orchestration chain (`53/54/55/56/57/58/90`)
- update contributor docs to reflect the expanded strict-mode coverage list
- log validation and rationale in progress notes

## Why
The launch reliability path depends on preflight, staged checks, auth, and runtime recovery scripts in addition to the existing orchestrators. Regressing strict mode in any of these files should be caught before merge.

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

Closes #17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI validation and documentation, tightening checks to fail builds when critical shell orchestrators lose strict mode.
> 
> **Overview**
> Expands `scripts/99-ci-validate.sh` strict-mode guardrails to require `set -euo pipefail` across the full critical orchestration chain (`53/54/55/56/57/58/90`), preventing regressions in preflight, staged checks, auth, and recovery scripts from slipping through CI.
> 
> Updates contributor docs (`README.md`) and records the rationale/validation in `docs/progress.md` to reflect the expanded coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31e997fb48b48c92fbb85d2a621ab05b33aecbd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->