### PR TITLE
CI: validate script refs across all tracked markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity across tracked markdown files, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,19 @@
 # Progress Log
 
+## 2026-03-01 (tracked-markdown docs integrity guardrails)
+
+Validation from this checkout:
+
+- Expanded `scripts/99-ci-validate.sh` docs script-reference checks to scan all tracked markdown files (`git ls-files '*.md'`) instead of only a fixed subset.
+- Fixed one stale historical script reference in this log that pointed to a removed legacy trace script path.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a documentation-drift gap where stale script references outside the previously-scanned docs set could silently survive and break command copy/paste reliability.
+
 ## 2026-03-01 (expanded strict-mode CI guardrails across critical orchestration chain)
 
 Validation from this checkout:
@@ -2800,7 +2814,7 @@ Assessment update:
 
 Live validation on `spark-de79` against the current runtime state:
 
-- Re-ran latest package/bootstrap trace flow (`scripts/53-trace-msfs-package-probes-and-retest.sh` in remote working copy).
+- Re-ran latest package/bootstrap trace flow (legacy `53-trace-msfs-package-probes-and-retest.sh` from the remote working copy at that time).
 - Bootstrap confirms MSFS 2024 package content is present under canonical tree (`markers=260`) and symlink bridge/UserCfg path rewrites are applied.
 - Dispatch is currently blocked upstream of game launch due to Steam runtime/webhelper instability in this session:
   - repeated `bwrap: execvp /usr/lib/pressure-vessel/from-host/libexec/steam-runtime-tools-0/pv-adverb: No such file or directory`

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -24,17 +24,21 @@ while IFS= read -r script_path; do
 done < <(find scripts -maxdepth 1 -type f -name '[0-9][0-9]-*.sh' | sort)
 
 echo "==> Docs script-reference checks"
+mapfile -t markdown_files < <(git ls-files '*.md')
+if [[ "${#markdown_files[@]}" -eq 0 ]]; then
+  echo "WARN: no tracked markdown files found; skipping docs script-reference checks."
+fi
+
 list_doc_script_refs() {
+  if [[ "${#markdown_files[@]}" -eq 0 ]]; then
+    return 0
+  fi
   if [[ "${have_rg}" -eq 1 ]]; then
     rg --no-filename -o 'scripts/[0-9][0-9]-[A-Za-z0-9_.-]+\.sh' \
-      README.md \
-      docs/setup-guide.md \
-      docs/troubleshooting.md || true
+      "${markdown_files[@]}" || true
   else
     grep -Eho 'scripts/[0-9][0-9]-[A-Za-z0-9_.-]+\.sh' \
-      README.md \
-      docs/setup-guide.md \
-      docs/troubleshooting.md || true
+      "${markdown_files[@]}" || true
   fi
 }
 


### PR DESCRIPTION
## Summary
- expand docs script-reference CI guardrails to scan all tracked markdown files (`git ls-files '*.md'`)
- keep `rg`/`grep` fallback behavior while reusing the same markdown file list
- fix stale historical reference in `docs/progress.md` and update contributing docs text

Closes #19

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI validation and documentation updates, with no impact on runtime/launch logic beyond tightening pre-merge checks.
> 
> **Overview**
> CI validation now checks `scripts/NN-*.sh` references across **all tracked markdown files** (via `git ls-files '*.md'`) instead of a fixed docs subset, and skips with a warning when no markdown is tracked.
> 
> Docs were updated to reflect the broadened guardrail, including fixing a stale historical script reference in `docs/progress.md` and clarifying the `README.md` contributing guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4cd545efec8b1feb508e5886789cfe670b342da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->