### PR TITLE
ci: enforce bash shebang guardrails for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, executable bits, docs script-reference integrity across tracked markdown files, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, docs script-reference integrity across tracked markdown files, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,20 @@
 # Progress Log
 
+## 2026-03-01 (CI shebang guardrails for Bash scripts)
+
+Validation from this checkout:
+
+- Added shebang validation to `scripts/99-ci-validate.sh` for all `scripts/*.sh` files.
+- CI now fails if any script does not start with `#!/usr/bin/env bash`.
+- Updated `README.md` contributor guidance to include shebang guardrails.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a shell-execution reliability gap where accidental shebang drift could force `/bin/sh` behavior and break Bash-specific orchestration paths.
+
 ## 2026-03-01 (tracked-markdown docs integrity guardrails)
 
 Validation from this checkout:

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -15,6 +15,15 @@ while IFS= read -r script_path; do
   bash -n "${script_path}"
 done < <(find scripts -maxdepth 1 -type f -name '*.sh' | sort)
 
+echo "==> Shebang guardrails"
+while IFS= read -r script_path; do
+  shebang_line="$(head -n 1 "${script_path}")"
+  if [[ "${shebang_line}" != "#!/usr/bin/env bash" ]]; then
+    echo "ERROR: expected '#!/usr/bin/env bash' in ${script_path}" >&2
+    exit 1
+  fi
+done < <(find scripts -maxdepth 1 -type f -name '*.sh' | sort)
+
 echo "==> Executable bit checks"
 while IFS= read -r script_path; do
   if [[ ! -x "${script_path}" ]]; then


### PR DESCRIPTION
## Summary
- add CI shebang guardrails for all `scripts/*.sh`
- fail validation when script shebang is not `#!/usr/bin/env bash`
- update contributor guidance and progress log

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

Closes #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra CI validation check and minor documentation updates, with no runtime behavior changes beyond failing CI when scripts have non-compliant shebangs.
> 
> **Overview**
> Adds a new CI guardrail in `scripts/99-ci-validate.sh` to verify every `scripts/*.sh` starts with `#!/usr/bin/env bash`, failing validation if any script drifts.
> 
> Updates contributor guidance in `README.md` and records the new validation in `docs/progress.md` so local/CI expectations match the stricter Bash execution requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e170d06b8f469e82bc6a68222180a96c0cc3635. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->