### PR TITLE
Add CI check for local markdown link integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,21 @@
 # Progress Log
 
+## 2026-03-01 (CI local markdown-link integrity checks)
+
+Validation from this checkout:
+
+- Extended `scripts/99-ci-validate.sh` with local markdown-link integrity checks across all tracked markdown files.
+- The validator now extracts inline markdown links and fails when a relative/local target does not exist.
+- Link validation intentionally skips external schemes (`http:`, `https:`, `mailto:`, etc.) and anchor-only links.
+- Updated `README.md` contributing guidance to include this new docs-integrity guardrail.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a documentation reliability gap where broken local links could ship unnoticed and degrade onboarding/troubleshooting workflows.
+
 ## 2026-03-01 (unique numbered-script prefix guardrails)
 
 Validation from this checkout:


### PR DESCRIPTION
## Summary
- extend `scripts/99-ci-validate.sh` with local markdown-link integrity checks across tracked docs
- fail CI when relative markdown link targets are missing
- skip external-scheme and anchor-only links
- document the guardrail in `README.md` and log it in `docs/progress.md`

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

Closes #25

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additional validation step in the CI/local validator and updates documentation; it only affects PR gating and could introduce false negatives if link parsing is too strict.
> 
> **Overview**
> Adds a new docs guardrail to `scripts/99-ci-validate.sh` that scans tracked markdown files for inline links and fails validation when a *relative/local* link target doesn’t exist (skipping external URL schemes and anchor-only links).
> 
> Updates contributor documentation (`README.md` and `docs/progress.md`) to reflect and record the new local markdown link integrity check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 206cab2b8a470906d219aa2efd7803fa7a216b68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->