### PR TITLE
Harden lock regression coverage with forced mkdir fallback mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ When `AUTO_REAUTH_ON_AUTH_FAILURE=1` is enabled and auth recovery fails, `90-rem
 Pipe-write tuning is now also forwarded end-to-end by `90-remote-dgx-stable-check.sh`: `PIPE_WRITE_TIMEOUT_SECONDS` (default `6`), `PIPE_WRITE_RETRIES` (default `3`), `PIPE_WRITE_RETRY_DELAY_SECONDS`, `PIPE_WRITE_RECOVER_ON_TIMEOUT`, and URI fallback controls (`URI_FALLBACK_ON_PIPE_FAILURE`, `URI_FALLBACK_TIMEOUT_SECONDS`).
 When dispatch still fails, fallback now runs as an ordered chain (`DISPATCH_FALLBACK_CHAIN`, default `applaunch,steam_uri,snap_uri`) and can auto-normalize Steam windows first (`DISPATCH_FORCE_UI_ON_FAILURE=1`) to recover from hidden/off-screen UI states before retrying launch methods.
 Critical orchestrators now fail-fast on concurrent runs by default (`ENABLE_SCRIPT_LOCKS=1`): `54-launch-and-capture-evidence.sh`, `55-run-until-stable-runtime.sh`, and `90-remote-dgx-stable-check.sh`. Use `MSFS_LAUNCH_LOCK_WAIT_SECONDS`, `MSFS_STABLE_RUN_LOCK_WAIT_SECONDS`, and `MSFS_REMOTE_CHECK_LOCK_WAIT_SECONDS` to wait for active runs instead of exiting immediately.
-Busy lock diagnostics now include lock-holder PID context when available (for example `holder pid: 12345`) and fallback lock mode can auto-reclaim stale lock directories by default (`MSFS_LOCK_RECLAIM_STALE=1`).
+Busy lock diagnostics now include lock-holder PID context when available (for example `holder pid: 12345`) and fallback lock mode can auto-reclaim stale lock directories by default (`MSFS_LOCK_RECLAIM_STALE=1`). For deterministic fallback-path testing/debugging, set `MSFS_FORCE_MKDIR_LOCK=1` to bypass `flock` and force mkdir lock mode.
 
 See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [docs/progress.md](docs/progress.md) for live validation notes.
 
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh`).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,28 @@
 # Progress Log
 
+## 2026-03-01 (mkdir-fallback lock-path regression coverage)
+
+Validation from this checkout:
+
+- Added deterministic fallback-backend control in `scripts/lib-lock.sh`:
+  - new env toggle `MSFS_FORCE_MKDIR_LOCK=1` bypasses `flock` and forces mkdir lock mode,
+  - invalid toggle values now fail fast with a clear validation error.
+- Expanded lock behavioral regression tests in `scripts/98-test-lock-lib.sh`:
+  - verifies contention diagnostics in forced mkdir-fallback mode,
+  - verifies stale lockdir auto-reclaim during lock acquisition in fallback mode,
+  - verifies `MSFS_LOCK_RECLAIM_STALE=0` blocks acquisition on stale fallback lockdirs.
+- Updated docs:
+  - `README.md`
+  - `docs/troubleshooting.md`
+- Local verification:
+  - `bash -n scripts/lib-lock.sh scripts/98-test-lock-lib.sh` (pass)
+  - `./scripts/98-test-lock-lib.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a meaningful regression blind spot by validating both lock backends in CI/self-tests instead of only the default `flock` path.
+
 ## 2026-03-01 (CI local markdown-link integrity checks)
 
 Validation from this checkout:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -146,6 +146,9 @@ ENABLE_SCRIPT_LOCKS=0 ./scripts/90-remote-dgx-stable-check.sh
 
 # Optional: disable stale lockdir reclamation in mkdir-fallback mode
 MSFS_LOCK_RECLAIM_STALE=0 ./scripts/90-remote-dgx-stable-check.sh
+
+# Optional: force mkdir-fallback lock backend for deterministic debugging
+MSFS_FORCE_MKDIR_LOCK=1 ./scripts/90-remote-dgx-stable-check.sh
 ```
 
 ### Dispatch not accepted (`exit 4`) after auth succeeds

--- a/scripts/98-test-lock-lib.sh
+++ b/scripts/98-test-lock-lib.sh
@@ -80,4 +80,77 @@ if [ ! -d "$active_lock_dir" ]; then
   exit 1
 fi
 
+echo "[lock-test] mkdir fallback contention emits busy diagnostics"
+(
+  MSFS_LOCKS_DIR="$tmp_dir" MSFS_FORCE_MKDIR_LOCK=1 acquire_script_lock "ci-mkdir-contention" 0
+  sleep 3
+  release_script_lock
+) &
+mkdir_holder_job_pid=$!
+
+mkdir_lock_pid_file="$tmp_dir/ci-mkdir-contention.lockdir/pid"
+for _ in $(seq 1 40); do
+  [ -f "$mkdir_lock_pid_file" ] && break
+  sleep 0.1
+done
+if [ ! -f "$mkdir_lock_pid_file" ]; then
+  echo "ERROR: mkdir fallback holder pid file was not created in time." >&2
+  wait "$mkdir_holder_job_pid" || true
+  exit 1
+fi
+
+set +e
+mkdir_contention_output="$(
+  MSFS_LOCKS_DIR="$tmp_dir" MSFS_FORCE_MKDIR_LOCK=1 bash -c "source \"$SCRIPT_DIR/lib-lock.sh\"; acquire_script_lock 'ci-mkdir-contention' 0" 2>&1
+)"
+mkdir_contention_rc=$?
+set -e
+
+wait "$mkdir_holder_job_pid"
+
+if [ "$mkdir_contention_rc" -eq 0 ]; then
+  echo "ERROR: mkdir contention test unexpectedly acquired lock." >&2
+  exit 1
+fi
+if ! grep -q "ERROR: lock busy: ci-mkdir-contention" <<<"$mkdir_contention_output"; then
+  echo "ERROR: mkdir contention output missing lock-busy diagnostic." >&2
+  echo "$mkdir_contention_output" >&2
+  exit 1
+fi
+if ! grep -q "holder pid:" <<<"$mkdir_contention_output"; then
+  echo "ERROR: mkdir contention output missing holder pid context." >&2
+  echo "$mkdir_contention_output" >&2
+  exit 1
+fi
+
+echo "[lock-test] mkdir fallback auto-reclaims stale lockdir during acquire"
+mkdir -p "$tmp_dir/ci-mkdir-stale.lockdir"
+printf '%s\n' 999999 > "$tmp_dir/ci-mkdir-stale.lockdir/pid"
+MSFS_LOCKS_DIR="$tmp_dir" MSFS_FORCE_MKDIR_LOCK=1 acquire_script_lock "ci-mkdir-stale" 0
+if [ ! -f "$tmp_dir/ci-mkdir-stale.lockdir/pid" ]; then
+  echo "ERROR: expected lock pid file after stale lockdir reclaim acquire." >&2
+  release_script_lock
+  exit 1
+fi
+release_script_lock
+
+echo "[lock-test] mkdir fallback honors MSFS_LOCK_RECLAIM_STALE=0"
+mkdir -p "$tmp_dir/ci-mkdir-no-reclaim.lockdir"
+printf '%s\n' 999999 > "$tmp_dir/ci-mkdir-no-reclaim.lockdir/pid"
+set +e
+no_reclaim_output="$(
+  MSFS_LOCKS_DIR="$tmp_dir" MSFS_FORCE_MKDIR_LOCK=1 MSFS_LOCK_RECLAIM_STALE=0 bash -c "source \"$SCRIPT_DIR/lib-lock.sh\"; acquire_script_lock 'ci-mkdir-no-reclaim' 0" 2>&1
+)"
+no_reclaim_rc=$?
+set -e
+if [ "$no_reclaim_rc" -eq 0 ]; then
+  echo "ERROR: expected stale lockdir to block acquire when reclaim is disabled." >&2
+  exit 1
+fi
+if ! grep -q "ERROR: lock busy: ci-mkdir-no-reclaim" <<<"$no_reclaim_output"; then
+  echo "ERROR: missing lock-busy diagnostic when stale reclaim is disabled." >&2
+  echo "$no_reclaim_output" >&2
+  exit 1
+fi
+
 echo "Lock helper self-test passed."

--- a/scripts/lib-lock.sh
+++ b/scripts/lib-lock.sh
@@ -59,10 +59,16 @@ acquire_script_lock() {
   local lock_wait_seconds="${2:-0}"
   local locks_dir="${3:-${MSFS_LOCKS_DIR:-${XDG_RUNTIME_DIR:-/tmp}/msfs-on-dgx-spark-locks}}"
   local lock_reclaim_stale="${MSFS_LOCK_RECLAIM_STALE:-1}"
+  local force_mkdir_lock="${MSFS_FORCE_MKDIR_LOCK:-0}"
   local holder_note=""
   mkdir -p "$locks_dir"
 
-  if command -v flock >/dev/null 2>&1; then
+  if [[ "$force_mkdir_lock" != "0" && "$force_mkdir_lock" != "1" ]]; then
+    echo "ERROR: MSFS_FORCE_MKDIR_LOCK must be 0 or 1 (got: $force_mkdir_lock)"
+    return 1
+  fi
+
+  if [[ "$force_mkdir_lock" != "1" ]] && command -v flock >/dev/null 2>&1; then
     MSFS_LOCK_FILE="$locks_dir/${lock_name}.lock"
     exec {MSFS_LOCK_FD}> "$MSFS_LOCK_FILE"
     if ! [[ "$lock_wait_seconds" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- add deterministic lock-backend forcing (`MSFS_FORCE_MKDIR_LOCK=1`) in `scripts/lib-lock.sh`
- extend `scripts/98-test-lock-lib.sh` to validate mkdir-fallback contention and stale-lock behavior through `acquire_script_lock`
- document forced fallback debugging/testing in README + troubleshooting + progress log

## Problem
CI lock self-tests were validating the default `flock` path, but not the fallback `mkdir` backend behavior during lock acquisition. That left a regression blind spot for environments where `flock` is unavailable.

## Validation
- `bash -n scripts/lib-lock.sh scripts/98-test-lock-lib.sh`
- `./scripts/98-test-lock-lib.sh`
- `./scripts/99-ci-validate.sh`

Closes #27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: default locking behavior is unchanged unless `MSFS_FORCE_MKDIR_LOCK=1` is set, and the rest is additional validation, tests, and documentation. Main risk is any unforeseen interaction in environments that intentionally force the mkdir backend or previously set the variable to a non-`0/1` value.
> 
> **Overview**
> Adds an explicit `MSFS_FORCE_MKDIR_LOCK` toggle to `scripts/lib-lock.sh` to bypass `flock` and deterministically exercise the mkdir-based lock backend, with fail-fast validation on invalid values.
> 
> Expands `scripts/98-test-lock-lib.sh` to cover mkdir-backend contention diagnostics and stale-lockdir reclaim behavior (including `MSFS_LOCK_RECLAIM_STALE=0`), and updates `README.md`/`docs/troubleshooting.md`/`docs/progress.md` to document the new debugging and CI coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94cfb89006d387c442b206e0185cecc732d9c641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->