### PR TITLE
CI: block CRLF and BOM drift in tracked text files

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, text-file CRLF/BOM guardrails (`scripts/*.sh`, tracked markdown, and workflow YAML), strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,25 @@
 # Progress Log
 
+## 2026-03-01 (CI CRLF/BOM drift guardrails)
+
+Validation from this checkout:
+
+- Expanded `scripts/99-ci-validate.sh` with text-file encoding/line-ending guardrails for tracked:
+  - `scripts/*.sh`
+  - `*.md`
+  - `.github/workflows/*.yml`
+- Validator now fails when any guarded file contains:
+  - CRLF line endings (`\\r\\n`)
+  - UTF-8 BOM prefix (`EF BB BF`)
+- Updated `README.md` contributor guidance to include the new CRLF/BOM guardrails.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a cross-platform reliability gap where Windows-style line endings or BOM-prefixed files could introduce subtle shell parsing/shebang issues and noisy diffs.
+
 ## 2026-03-01 (mkdir-fallback lock-path regression coverage)
 
 Validation from this checkout:


### PR DESCRIPTION
## Summary
- add CI guardrails in `scripts/99-ci-validate.sh` to fail on CRLF line endings in tracked shell/docs/workflow files
- add CI guardrails to fail on UTF-8 BOM-prefixed tracked shell/docs/workflow files
- update contributor docs and progress log

Closes #29

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds additional CI validation checks that only affect contributions by failing builds when files contain CRLF line endings or a UTF-8 BOM.
> 
> **Overview**
> Adds new text-file hygiene checks to `scripts/99-ci-validate.sh` that **fail CI** if any tracked `scripts/*.sh`, `*.md`, or `.github/workflows/*.yml` contains CRLF line endings or a UTF-8 BOM.
> 
> Updates contributor-facing docs (`README.md` and `docs/progress.md`) to document the new guardrails and why they’re enforced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a76fca4b0d325dfdc55b5c774b21987888eec54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->