### PR TITLE
CI: enforce strict mode for all numbered scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, text-file CRLF/BOM guardrails (`scripts/*.sh`, tracked markdown, and workflow YAML), strict-mode guardrails for critical launch/auth/recovery orchestrators (`53`, `54`, `55`, `56`, `57`, `58`, `90`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, text-file CRLF/BOM guardrails (`scripts/*.sh`, tracked markdown, and workflow YAML), strict-mode guardrails for all numbered scripts (`scripts/[0-9][0-9]-*.sh`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,19 @@
 # Progress Log
 
+## 2026-03-01 (strict-mode guardrails for all numbered scripts)
+
+Validation from this checkout:
+
+- Expanded `scripts/99-ci-validate.sh` strict-mode guardrails to cover all numbered scripts (`scripts/[0-9][0-9]-*.sh`) instead of only a hand-picked critical subset.
+- Updated `README.md` contributor guidance to reflect full numbered-script strict-mode coverage.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a CI regression gap where strict-mode drift in non-critical numbered scripts could previously merge unnoticed.
+
 ## 2026-03-01 (strict lock-toggle input validation)
 
 Validation from this checkout:

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -156,22 +156,13 @@ for file_path in "${text_guardrail_files[@]}"; do
   fi
 done
 
-echo "==> Strict-mode guardrails (critical orchestrators)"
-critical_strict_scripts=(
-  "scripts/53-preflight-runtime-repair.sh"
-  "scripts/54-launch-and-capture-evidence.sh"
-  "scripts/55-run-until-stable-runtime.sh"
-  "scripts/56-run-staged-stability-check.sh"
-  "scripts/57-recover-steam-runtime.sh"
-  "scripts/58-ensure-steam-auth.sh"
-  "scripts/90-remote-dgx-stable-check.sh"
-)
-for script_path in "${critical_strict_scripts[@]}"; do
+echo "==> Strict-mode guardrails (numbered scripts)"
+while IFS= read -r script_path; do
   if ! grep -qx 'set -euo pipefail' "${script_path}"; then
     echo "ERROR: missing strict mode header in ${script_path}" >&2
     exit 1
   fi
-done
+done < <(find scripts -maxdepth 1 -type f -name '[0-9][0-9]-*.sh' | sort)
 
 echo "==> Hardcoded sudo password guardrails"
 hardcoded_sudo_pattern="echo[[:space:]]+[\"'][^\"']+[\"'][[:space:]]*\\|[[:space:]]*sudo[[:space:]]+-S"


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` guardrails for all numbered scripts (`scripts/[0-9][0-9]-*.sh`)
- update contributor docs to match new strict-mode scope
- record the change and validation in `docs/progress.md`

## Why
Strict mode was previously enforced only for a subset of critical scripts. This allowed strict-mode drift in other numbered orchestrators to bypass CI.

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

Closes #34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI validation and documentation, but could cause new CI failures if any existing numbered script lacks `set -euo pipefail`.
> 
> **Overview**
> **CI now enforces Bash strict mode across all numbered scripts.** `scripts/99-ci-validate.sh` expands the `set -euo pipefail` guardrail from a fixed “critical” list to every `scripts/[0-9][0-9]-*.sh` file.
> 
> Docs are updated to match: `README.md` contributor guidance now reflects full numbered-script coverage, and `docs/progress.md` records the change plus local validation results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3e3047c90f0bec1ec1e528c3ea3fd2b71026177. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->