### PR TITLE
ci: block unresolved merge-conflict markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 
 This is uncharted territory. If you have a DGX Spark and want to help, open an issue or PR. Particularly useful:
 
-- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, text-file CRLF/BOM guardrails (`scripts/*.sh`, tracked markdown, and workflow YAML), strict-mode guardrails for all numbered scripts (`scripts/[0-9][0-9]-*.sh`), hardcoded sudo-password pattern blocking, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
+- Run `./scripts/99-ci-validate.sh` before opening a PR (same checks as GitHub Actions CI: syntax, shebang guardrails (`#!/usr/bin/env bash`), executable bits, unique two-digit numbered-script prefixes, docs script-reference integrity across tracked markdown files, local markdown-link integrity checks for tracked docs, text-file CRLF/BOM guardrails (`scripts/*.sh`, tracked markdown, and workflow YAML), strict-mode guardrails for all numbered scripts (`scripts/[0-9][0-9]-*.sh`), hardcoded sudo-password pattern blocking, merge-conflict marker blocking in tracked files, `shellcheck -S error` across `scripts/*.sh`, and behavioral lock self-tests via `scripts/98-test-lock-lib.sh` including forced mkdir-fallback coverage).
 - Testing MSFS with different Proton versions
 - Profiling performance bottlenecks (CPU translation vs GPU vs memory bandwidth)
 - Arxan DRM compatibility findings

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,20 @@
 # Progress Log
 
+## 2026-03-01 (CI merge-conflict marker guardrails)
+
+Validation from this checkout:
+
+- Extended `scripts/99-ci-validate.sh` with merge-conflict marker detection across tracked files.
+- Validator now fails fast when unresolved Git conflict markers are present (`<<<<<<<`, `=======`, `>>>>>>>`).
+- Updated contributor guidance in `README.md` to include the new guardrail.
+- Local verification:
+  - `bash -n scripts/99-ci-validate.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This closes a high-impact CI blind spot where accidental unresolved merge conflicts could otherwise land and break scripts/docs at runtime.
+
 ## 2026-03-01 (lock-name validation for safe lock paths)
 
 Validation from this checkout:

--- a/scripts/99-ci-validate.sh
+++ b/scripts/99-ci-validate.sh
@@ -173,6 +173,13 @@ if grep -RInE "${hardcoded_sudo_pattern}" scripts/*.sh >/dev/null; then
   exit 1
 fi
 
+echo "==> Merge-conflict marker guardrails"
+if git grep -nE '^(<<<<<<< |=======|>>>>>>> )' -- . >/dev/null; then
+  echo "ERROR: unresolved merge-conflict markers detected in tracked files." >&2
+  git grep -nE '^(<<<<<<< |=======|>>>>>>> )' -- . >&2 || true
+  exit 1
+fi
+
 echo "==> ShellCheck error-level guardrails"
 if ! command -v shellcheck >/dev/null 2>&1; then
   echo "ERROR: shellcheck is required but was not found in PATH." >&2


### PR DESCRIPTION
## Summary
Add CI guardrails to fail fast on unresolved merge-conflict markers in tracked files.

## Changes
- `scripts/99-ci-validate.sh`
  - Added a new validation phase:
    - scans tracked files with `git grep -nE '^(<<<<<<< |=======|>>>>>>> )' -- .`
    - fails with matching file/line output when markers are found
- `README.md`
  - Updated contributor CI-check summary to include merge-conflict marker blocking
- `docs/progress.md`
  - Logged rationale and validation results

## Why this matters
Unresolved conflict markers can break shell scripts or docs and are easy to miss during manual review. This adds a cheap, deterministic CI backstop.

## Validation
- `bash -n scripts/99-ci-validate.sh`
- `./scripts/99-ci-validate.sh`

Closes #40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra CI validation step that only fails builds when tracked files contain unresolved merge-conflict markers, plus documentation updates.
> 
> **Overview**
> Adds a new phase to `scripts/99-ci-validate.sh` that scans tracked files for unresolved Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and fails fast while printing matches.
> 
> Updates `README.md` contributor guidance and `docs/progress.md` to document the new merge-conflict guardrail and local validation results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d980837b30fbbd0d03b925a564b05cdaa5708e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->