### PR TITLE
Automate Steam launch prompt confirmation for unattended runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ NVIDIA GB10 Blackwell GPU
 # 8. Optional: one-shot finalize (Steam Guard code -> install -> launch)
 ./scripts/08-finalize-auth-and-run-msfs.sh <STEAM_GUARD_CODE>
 
+# 8b. Optional: run Steam prompt auto-confirm helper directly
+AUTO_CONFIRM_SECONDS=120 ./scripts/60-auto-confirm-steam-prompts.sh
+
 # 9. Optional: verify MSFS launch reached stable runtime
 ./scripts/09-verify-msfs-launch.sh
 
@@ -186,6 +189,7 @@ When auth drift is expected, `AUTO_REAUTH_ON_AUTH_FAILURE=1` runs `58-ensure-ste
 `58-ensure-steam-auth.sh` now also attempts to restore/focus Steam windows by default (`AUTH_RESTORE_WINDOWS=1`), which helps when dialogs are present but headless-minimized.
 During restore, auth recovery now also normalizes Steam window geometry by default (`AUTH_NORMALIZE_WINDOWS=1`, `AUTH_WINDOW_WIDTH=1600`, `AUTH_WINDOW_HEIGHT=900`, `AUTH_WINDOW_X=50`, `AUTH_WINDOW_Y=50`) so tiny/off-screen windows become visible for VNC/manual login.
 Auth checks now require strong Steam session evidence by default (`steamid` via process/log); UI-only detection is treated as unauthenticated unless `ALLOW_UI_AUTH_FALLBACK=1` is explicitly set.
+Launch orchestrators now auto-start `60-auto-confirm-steam-prompts.sh` by default to acknowledge common Steam modal prompts during unattended launches (`AUTO_CONFIRM_ON_LAUNCH=1` in `05-resume-headless-msfs.sh`, `AUTO_CONFIRM_PROMPTS=1` in `08-finalize-auth-and-run-msfs.sh`). Tune helper lifetime with `AUTO_CONFIRM_SECONDS` or disable explicitly with `0`.
 `90-remote-dgx-stable-check.sh` forwards `ALLOW_UI_AUTH_FALLBACK` and `FATAL_EXIT_CODES` to the remote runners, and also accepts trailing `KEY=VALUE` overrides for convenience (for example `./scripts/90-remote-dgx-stable-check.sh MIN_STABLE_SECONDS=30 MAX_ATTEMPTS=1`).
 `90-remote-dgx-stable-check.sh` can load an optional remote auth env file (`REMOTE_AUTH_ENV_FILE`, default `$HOME/.config/msfs-on-dgx-spark/steam-auth.env`) and will enforce `0600` permissions by default (`REQUIRE_REMOTE_AUTH_ENV_PERMS=1`) before sourcing it.
 `90-remote-dgx-stable-check.sh` can also push a local auth env to DGX before execution (`PUSH_REMOTE_AUTH_ENV=1`, `LOCAL_AUTH_ENV_FILE=...`), with `0600` enforcement on both sides by default.
@@ -233,6 +237,7 @@ See [docs/setup-guide.md](docs/setup-guide.md) for detailed instructions, and [d
 │   ├── 56-run-staged-stability-check.sh # Baseline + strict staged stability gates
 │   ├── 57-recover-steam-runtime.sh # Rebuild Steam runtime namespace between retries
 │   ├── 58-ensure-steam-auth.sh # Ensure authenticated Steam session (optional credential + Steam Guard automation)
+│   ├── 60-auto-confirm-steam-prompts.sh # Best-effort Steam prompt auto-confirm helper for unattended launch
 │   ├── 90-remote-dgx-stable-check.sh # Sync current checkout to DGX and run staged checks remotely
 │   ├── 14-install-ge-proton.sh # Install latest GE-Proton into compatibilitytools.d
 └── docs/

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,26 @@
 # Progress Log
 
+## 2026-03-01 (unattended Steam prompt auto-confirm during launch)
+
+Validation from this checkout:
+
+- Added new helper script `scripts/60-auto-confirm-steam-prompts.sh`:
+  - best-effort Steam prompt automation via `xdotool` over a bounded timeout window,
+  - validates numeric env knobs (`AUTO_CONFIRM_SECONDS`, `AUTO_CONFIRM_INTERVAL`, `AUTO_CONFIRM_MAX_WINDOWS`),
+  - exits cleanly as a no-op when required UI tool dependencies are unavailable.
+- Updated launch orchestrators to start the helper automatically by default:
+  - `scripts/05-resume-headless-msfs.sh` (`AUTO_CONFIRM_ON_LAUNCH=1`, `AUTO_CONFIRM_SECONDS`),
+  - `scripts/08-finalize-auth-and-run-msfs.sh` (`AUTO_CONFIRM_PROMPTS=1`, `AUTO_CONFIRM_SECONDS`) with exit-trap cleanup for background helper lifecycle.
+- Updated docs:
+  - `README.md`
+- Local verification:
+  - `bash -n scripts/05-resume-headless-msfs.sh scripts/08-finalize-auth-and-run-msfs.sh scripts/60-auto-confirm-steam-prompts.sh` (pass)
+  - `./scripts/99-ci-validate.sh` (pass)
+
+Assessment update:
+
+- This reduces manual VNC intervention for first-run Steam confirmation dialogs and improves unattended MSFS launch reliability in headless DGX sessions.
+
 ## 2026-03-01 (CI merge-conflict marker guardrails)
 
 Validation from this checkout:

--- a/scripts/05-resume-headless-msfs.sh
+++ b/scripts/05-resume-headless-msfs.sh
@@ -11,6 +11,8 @@ DISPLAY_NUM="$(resolve_display_num "$SCRIPT_DIR")"
 RESOLUTION="${RESOLUTION:-1920x1080x24}"
 MSFS_APPID="${MSFS_APPID:-2537590}"
 ACTION="${1:-install}"   # install|launch
+AUTO_CONFIRM_ON_LAUNCH="${AUTO_CONFIRM_ON_LAUNCH:-1}"
+AUTO_CONFIRM_SECONDS="${AUTO_CONFIRM_SECONDS:-90}"
 
 find_steam_dir() {
     local paths=(
@@ -62,6 +64,11 @@ if [ "$ACTION" = "install" ]; then
 else
     timeout 12s env DISPLAY="$DISPLAY_NUM" steam "steam://rungameid/${MSFS_APPID}" >/tmp/msfs-launch-uri.log 2>&1 || true
     echo "Triggered Steam launch URI for AppID ${MSFS_APPID}."
+    if [ "$AUTO_CONFIRM_ON_LAUNCH" = "1" ] && [ -x "$SCRIPT_DIR/60-auto-confirm-steam-prompts.sh" ]; then
+        DISPLAY_NUM="$DISPLAY_NUM" AUTO_CONFIRM_SECONDS="$AUTO_CONFIRM_SECONDS" \
+          "$SCRIPT_DIR/60-auto-confirm-steam-prompts.sh" >/tmp/msfs-auto-confirm.log 2>&1 &
+        echo "Started auto-confirm helper for launch prompts (${AUTO_CONFIRM_SECONDS}s)."
+    fi
 fi
 
 echo ""

--- a/scripts/60-auto-confirm-steam-prompts.sh
+++ b/scripts/60-auto-confirm-steam-prompts.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Best-effort UI automation for Steam/MSFS first-run prompts on headless DGX.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-display.sh"
+source "$SCRIPT_DIR/lib-steam-auth.sh"
+
+DISPLAY_NUM="${DISPLAY_NUM:-$(resolve_display_num "$SCRIPT_DIR")}"
+AUTO_CONFIRM_SECONDS="${AUTO_CONFIRM_SECONDS:-120}"
+AUTO_CONFIRM_INTERVAL="${AUTO_CONFIRM_INTERVAL:-2}"
+AUTO_CONFIRM_MAX_WINDOWS="${AUTO_CONFIRM_MAX_WINDOWS:-6}"
+
+if ! [[ "$AUTO_CONFIRM_SECONDS" =~ ^[0-9]+$ ]] || [ "$AUTO_CONFIRM_SECONDS" -lt 1 ]; then
+  echo "ERROR: AUTO_CONFIRM_SECONDS must be a positive integer"
+  exit 2
+fi
+if ! [[ "$AUTO_CONFIRM_INTERVAL" =~ ^[0-9]+$ ]] || [ "$AUTO_CONFIRM_INTERVAL" -lt 1 ]; then
+  echo "ERROR: AUTO_CONFIRM_INTERVAL must be a positive integer"
+  exit 2
+fi
+if ! [[ "$AUTO_CONFIRM_MAX_WINDOWS" =~ ^[0-9]+$ ]] || [ "$AUTO_CONFIRM_MAX_WINDOWS" -lt 1 ]; then
+  echo "ERROR: AUTO_CONFIRM_MAX_WINDOWS must be a positive integer"
+  exit 2
+fi
+
+for cmd in xdotool; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "WARN: missing required tool: $cmd"
+    exit 0
+  fi
+done
+
+click_window_hotspots() {
+  local window_id="$1"
+  local geom x y w h
+  geom="$(timeout 3s env DISPLAY="$DISPLAY_NUM" xdotool getwindowgeometry --shell "$window_id" 2>/dev/null || true)"
+  [ -n "$geom" ] || return 0
+
+  # shellcheck disable=SC2034
+  eval "$geom"
+  x="${X:-0}"
+  y="${Y:-0}"
+  w="${WIDTH:-0}"
+  h="${HEIGHT:-0}"
+
+  [ "$w" -gt 0 ] || return 0
+  [ "$h" -gt 0 ] || return 0
+
+  # Click center and bottom-right where Steam buttons ("Play", "OK", "Continue")
+  # are commonly rendered.
+  timeout 3s env DISPLAY="$DISPLAY_NUM" xdotool mousemove --sync $((x + w / 2)) $((y + h / 2)) click 1 >/dev/null 2>&1 || true
+  timeout 3s env DISPLAY="$DISPLAY_NUM" xdotool mousemove --sync $((x + w - 140)) $((y + h - 55)) click 1 >/dev/null 2>&1 || true
+}
+
+echo "Auto-confirming Steam prompts on ${DISPLAY_NUM} for up to ${AUTO_CONFIRM_SECONDS}s"
+start_ts="$(date +%s)"
+while true; do
+  now="$(date +%s)"
+  elapsed=$(( now - start_ts ))
+  if [ "$elapsed" -ge "$AUTO_CONFIRM_SECONDS" ]; then
+    echo "Auto-confirm timeout reached (${AUTO_CONFIRM_SECONDS}s)"
+    break
+  fi
+
+  steam_force_show_windows "$DISPLAY_NUM" >/dev/null 2>&1 || true
+
+  mapfile -t win_ids < <(steam_window_ids "$DISPLAY_NUM" 2>/dev/null || true)
+  if [ "${#win_ids[@]}" -gt 0 ]; then
+    processed=0
+    for wid in "${win_ids[@]}"; do
+      processed=$((processed + 1))
+      if [ "$processed" -gt "$AUTO_CONFIRM_MAX_WINDOWS" ]; then
+        break
+      fi
+      timeout 3s env DISPLAY="$DISPLAY_NUM" xdotool windowactivate "$wid" >/dev/null 2>&1 || true
+      timeout 3s env DISPLAY="$DISPLAY_NUM" xdotool key --window "$wid" --delay 80 Escape Return >/dev/null 2>&1 || true
+      timeout 3s env DISPLAY="$DISPLAY_NUM" xdotool key --window "$wid" --delay 80 Tab Tab Return >/dev/null 2>&1 || true
+      click_window_hotspots "$wid"
+    done
+  fi
+
+  sleep "$AUTO_CONFIRM_INTERVAL"
+done


### PR DESCRIPTION
## Summary
- add `scripts/60-auto-confirm-steam-prompts.sh` to best-effort auto-confirm common Steam launch dialogs on headless displays
- wire auto-confirm helper into launch orchestrators:
  - `scripts/05-resume-headless-msfs.sh`
  - `scripts/08-finalize-auth-and-run-msfs.sh`
- document helper usage and behavior in `README.md`
- log validation and rationale in `docs/progress.md`

## Why
Unattended MSFS launch can stall on Steam modal prompts that require manual VNC interaction. This adds a bounded helper to reduce manual intervention and improve launch reliability.

## Validation
- `bash -n scripts/05-resume-headless-msfs.sh scripts/08-finalize-auth-and-run-msfs.sh scripts/60-auto-confirm-steam-prompts.sh`
- `./scripts/99-ci-validate.sh`

Closes #42

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds UI automation that sends clicks/keystrokes to Steam windows during launch; while bounded and opt-out, it could mis-click unexpected dialogs or interfere with manual sessions.
> 
> **Overview**
> Adds a new best-effort helper `scripts/60-auto-confirm-steam-prompts.sh` that uses `xdotool` (with validated, bounded env controls) to surface Steam windows and automatically attempt to dismiss/confirm common modal prompts during headless runs.
> 
> Wires the helper into the main launch orchestrators by default (`scripts/05-resume-headless-msfs.sh` and `scripts/08-finalize-auth-and-run-msfs.sh`), including configurable timeouts and cleanup/trap handling for the background process. Documentation is updated in `README.md` and logged in `docs/progress.md` with usage notes and validation steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee5bfb214dadbb54f2d25edb07216083cca0cda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->